### PR TITLE
Fix prepare of projects which use ns-unit-tests-runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,10 @@
 {
   "name": "nativescript-unit-test-runner",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "NativeScript unit test runner component.",
   "main": "app.js",
   "scripts": {
-    "test": "exit 0",
-    "preuninstall": "node preuninstall.js",
-    "postinstall": "node postinstall.js"
+    "test": "exit 0"
   },
   "repository": {
     "type": "git",
@@ -26,16 +24,6 @@
     "platforms": {
       "android": "1.6.0",
       "ios": "1.6.0"
-    },
-    "hooks": [
-      {
-        "type": "after-prepare",
-        "script": "lib/after-prepare.js",
-        "inject": true
-      }
-    ]
-  },
-  "dependencies": {
-    "nativescript-hook": "^0.2.1"
+    }
   }
 }

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,3 +1,0 @@
-var hook = require('nativescript-hook')(__dirname);
-hook.postinstall();
-

--- a/preuninstall.js
+++ b/preuninstall.js
@@ -1,1 +1,0 @@
-require('nativescript-hook')(__dirname).preuninstall();


### PR DESCRIPTION
`nativescript-hook` dependency has dependency on mkdirp module, which has its own executable.
After `npm install` is called, the executable is created in `<project dir>/node_modules/nativescript-unit-test-runner/node_modules/nativescript-hook/node_modules/.bin/mkdirp`. This file is symlink and when we try to copy it to platforms dir (that's CLI's bug - we should omit .bin dirs), the copy operation fails with EEXIST error.
Temporary remove the `nativesript-hook` dependency.