### PR TITLE
Ensure after-prepare hook is added to preoject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,5 @@ test-reports.xml
 
 npm-debug.log
 node_modules
-!preuninstall.js
-!postinstall.js
 !Gruntfile.js
 .d.ts

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,7 +86,7 @@ module.exports = function(grunt) {
 		},
 
 		clean: {
-			src: ["**/*.js*", "!**/*.json", "!postinstall.js", "!preuninstall.js", "!Gruntfile.js", "!node_modules/**/*", "*.tgz"]
+			src: ["**/*.js*", "!**/*.json", "!Gruntfile.js", "!node_modules/**/*", "*.tgz"]
 		}
 	});
 

--- a/lib/hook-helper.ts
+++ b/lib/hook-helper.ts
@@ -1,0 +1,38 @@
+"use strict";
+
+import * as fs from "fs";
+import * as path from "path";
+
+export function findProjectDir(){
+	// start from the root of ns-unit-test-runner
+	let candidateDir = path.join(__dirname, "..");
+
+	while (true) {
+		let oldCandidateDir = candidateDir;
+		candidateDir = path.dirname(candidateDir);
+		if (path.basename(candidateDir) === 'node_modules') {
+			continue;
+		}
+
+		let packageJsonFile = path.join(candidateDir, 'package.json');
+		if (fs.existsSync(packageJsonFile)) {
+			return candidateDir;
+		}
+
+		if (oldCandidateDir === candidateDir) {
+			return;
+		}
+	}
+}
+
+export function getHooksDir() {
+	return path.join(findProjectDir(), 'hooks')
+}
+
+export function getAfterPrepareHookDir() {
+	return path.join(getHooksDir(), "after-prepare");
+}
+
+export function getHookFilePath() {
+	return path.join(getAfterPrepareHookDir(), "nativescript-unit-test-runner.js");
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-unit-test-runner",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "NativeScript unit test runner component.",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "NativeScript unit test runner component.",
   "main": "app.js",
   "scripts": {
-    "test": "exit 0"
+    "test": "exit 0",
+    "postinstall": "node postinstall.js",
+    "preuninstall": "node preuninstall.js"
   },
   "repository": {
     "type": "git",

--- a/postinstall.ts
+++ b/postinstall.ts
@@ -1,0 +1,22 @@
+"use strict";
+
+import * as fs from "fs";
+import * as path from "path";
+import { EOL } from "os";
+import * as hookHelper from "./lib/hook-helper";
+
+let projectDir = hookHelper.findProjectDir();
+if(projectDir) {
+	let hooksDir = hookHelper.getHooksDir(),
+		afterPrepareHookDir = hookHelper.getAfterPrepareHookDir(),
+		content = 'module.exports = require("nativescript-unit-test-runner/lib/after-prepare");';
+	if(!fs.existsSync(hooksDir)) {
+		fs.mkdirSync(hooksDir);
+	}
+
+	if(!fs.existsSync(afterPrepareHookDir)) {
+		fs.mkdirSync(afterPrepareHookDir);
+	}
+
+	fs.writeFileSync(hookHelper.getHookFilePath(), content + EOL);
+}

--- a/preuninstall.ts
+++ b/preuninstall.ts
@@ -1,0 +1,10 @@
+"use strict";
+
+import * as fs from "fs";
+import * as hookHelper from "./lib/hook-helper";
+
+let hookPath = hookHelper.getHookFilePath();
+
+if (fs.existsSync(hookPath)) {
+	fs.unlinkSync(hookPath);
+}


### PR DESCRIPTION
Fix unit-test runner by adding logic to create required hooks on post-install.
Remove the hook file on preuninstall.