### PR TITLE
Don't emit "use strict" in JS output (default behavior in TS 1.8+)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,6 +41,7 @@ module.exports = function(grunt) {
 
 		ts: {
 			options: {
+				passThrough: true,
 				target: 'es5',
 				module: 'commonjs',
 				sourceMap: true,
@@ -48,7 +49,8 @@ module.exports = function(grunt) {
 				removeComments: false,
 				noImplicitAny: false,
 				experimentalDecorators: true,
-				emitDecoratorMetadata: true
+				emitDecoratorMetadata: true,
+				additionalFlags: "--noImplicitUseStrict"
 			},
 
 			devlib: {

--- a/main-view-model.ts
+++ b/main-view-model.ts
@@ -1,7 +1,4 @@
 /// <reference path="declarations.d.ts"/>
-
-"use strict";
-
 import observable = require("data/observable");
 import observableArray = require('data/observable-array');
 import http = require('http');


### PR DESCRIPTION
Since that breaks iOS deploys.