### PR TITLE
chore: migrate deprecated code

### DIFF
--- a/app-root.xml
+++ b/app-root.xml
@@ -1,0 +1,2 @@
+<Frame defaultPage="./tns_modules/nativescript-unit-test-runner/main-page">
+</Frame>

--- a/app.ts
+++ b/app.ts
@@ -1,3 +1,3 @@
-import * as application from "application";
-application.cssFile = "./tns_modules/nativescript-unit-test-runner/app.css";
-application.start({ moduleName: "./tns_modules/nativescript-unit-test-runner/main-page" });
+import * as application from "tns-core-modules/application";
+application.setCssFileName("./tns_modules/nativescript-unit-test-runner/app.css");
+application.run({ moduleName: "./tns_modules/nativescript-unit-test-runner/app-root" });

--- a/main-view-model.ts
+++ b/main-view-model.ts
@@ -1,10 +1,12 @@
 /// <reference path="declarations.d.ts"/>
-import observable = require("data/observable");
-import observableArray = require('data/observable-array');
-import http = require('http');
-import platform = require('platform');
-import frameModule = require('ui/frame');
+import observable = require('tns-core-modules/data/observable');
+import observableArray = require('tns-core-modules/data/observable-array');
+import http = require('tns-core-modules/http');
+import platform = require('tns-core-modules/platform');
+import frameModule = require('tns-core-modules/ui/frame');
 import stopProcess = require('./stop-process');
+
+declare var global: any;
 
 interface IHostConfiguration {
     port: number;
@@ -153,7 +155,7 @@ export class TestBrokerViewModel extends observable.Observable {
         });
 
         function formatName() {
-            return `NativeScript / ${ platform.device.sdkVersion } (${ platform.device.osVersion }; ${ platform.device.model })`;
+            return `NativeScript / ${platform.device.sdkVersion} (${platform.device.osVersion}; ${platform.device.model})`;
         }
 
         var connected = this.updateBanner('connected');
@@ -361,7 +363,7 @@ export class TestBrokerViewModel extends observable.Observable {
             }
         } else if (url.indexOf('chai') !== -1) {
             global.__shim_require = global.require;
-            global.require = function() {
+            global.require = function () {
                 throw Error();
             }
             global.window = global;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-shell": "^1.1.2",
     "grunt-ts": "^5.0.1",
+    "tns-core-modules": "^4.2.1",
     "typescript": "^1.8.2"
   },
   "nativescript": {


### PR DESCRIPTION
Migrate deprecated imports for `tns-core-modules`.
Migrate deprecated methods of `tns-core-modules/application` to the new recommended methods.