### PR TITLE
fix: add bundle-main-page.ts in order to work correctly with `ts` project

### DIFF
--- a/bundle-app-root.xml
+++ b/bundle-app-root.xml
@@ -1,2 +1,2 @@
-<Frame defaultPage="main-page" id="root-frame">
+<Frame defaultPage="bundle-main-page" id="root-frame">
 </Frame>

--- a/bundle-main-page.ts
+++ b/bundle-main-page.ts
@@ -1,0 +1,6 @@
+import vmModule = require("./main-view-model");
+function pageLoaded(args) {
+    var page = args.object;
+    page.bindingContext = vmModule.mainViewModel;
+}
+exports.pageLoaded = pageLoaded;

--- a/bundle-main-page.xml
+++ b/bundle-main-page.xml
@@ -1,0 +1,7 @@
+<Page xmlns="http://www.nativescript.org/tns.xsd" loaded="pageLoaded">
+    <GridLayout cssClass="landingContainer">
+        <Image src="{{ imageSrc }}" stretch="none" cssClass="landingBackground"/>
+
+        <Label text="{{ serverInfo }}" cssClass="landingText"/>
+    </GridLayout>
+</Page>


### PR DESCRIPTION
We need to add a separate `main-page` for the bundle case, as the `main-page.ts` file from the application is resolved with higher priority over `main-page.js` file from unit-test-runner