### PR TITLE
feat: add support for ts unit tests

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -44,6 +44,7 @@ interface IScriptInfo {
     localPath?: string;
     contents?: string;
     type?: ScriptTypes;
+    shouldEval?: boolean;
 }
 
 interface IKarmaHostResolver {
@@ -55,7 +56,7 @@ interface IKarmaConnectionService {
 }
 
 interface IKarmaFilesService {
-    getServedFilesData(baseUrl: string, config: IHostConfiguration): Promise<IScriptInfo[]>;
+    getServedFilesData(baseUrl: string): Promise<IScriptInfo[]>;
 }
 
 interface ITestExecutionService {

--- a/main-view-model.ts
+++ b/main-view-model.ts
@@ -70,7 +70,7 @@ export class TestBrokerViewModel extends Observable {
         this.startEmitted = false;
 
         this.karmaHostResolver = new KarmaHostResolver(http);
-        this.karmaFilesService = new KarmaFilesService(http);
+        this.karmaFilesService = new KarmaFilesService(http, config);
         this.testExecutionService = new TestExecutionService();
 
         this.karmaHostResolver.resolveKarmaHost(config.ips, config.port)
@@ -110,7 +110,7 @@ export class TestBrokerViewModel extends Observable {
 
         this.set('goToTestsText', 'View Test Run');
 
-        this.karmaFilesService.getServedFilesData(this.baseUrl, config)
+        this.karmaFilesService.getServedFilesData(this.baseUrl)
             .then((scriptsContents: IScriptInfo[]) => setTimeout(() => this.runTests(scriptsContents), 0));
     }
 

--- a/services/test-execution-service.ts
+++ b/services/test-execution-service.ts
@@ -30,12 +30,7 @@ export class TestExecutionService implements ITestExecutionService {
                 require(script.localPath);
             }
         } else {
-            const queryStringStart = script.url.lastIndexOf('?');
-            const pathWithoutQueryString = script.url.substring(0, queryStringStart);
-            const extensionRegex = /\.([^.\/]+)$/;
-            const fileExtension = extensionRegex.exec(pathWithoutQueryString)[1];
-
-            if (!fileExtension || fileExtension.toLowerCase() === "js") {
+            if (script.shouldEval) {
                 console.log('NSUTR: eval script ' + script.url);
                 this.loadShim(script.url);
                 //call eval indirectly to execute the scripts in the global scope


### PR DESCRIPTION
Currently karma server serves `.js` files when `--bundle` option is not provided and `.ts` files when `--bundle` option is provided. This leads to the problem that when a brand new project (`ts` or `ng`) is created and `--bundle` option is not provided, the tests are not executed. This happens because when karma server is started, `.js` files are still not produced as the `typescript` compilation is still not triggered (it is started before prepare the project e.g when livesync is started which is executed after starting karma server). If the `tns test` command is executed again and the project has no changes, everything works as expected as the `.js` files are produced. If the project has changes, this changes are not respected from the `tns test` command as the `.js` files are produced after starting karma server. The proposed solution relies on the followings:
* Karma server serves always `.ts` files
* NativeScript unit test runner requires local `.js` file when `.ts` file is served from karma. This way we're sure that the typescript compilation is triggered and at runtime are executed only `.js` files

Rel to: https://github.com/NativeScript/nativescript-cli/pull/4482