### PR TITLE
fix: make the hooks compatible with CLI v6.0.0 release

### DIFF
--- a/lib/after-prepare.ts
+++ b/lib/after-prepare.ts
@@ -1,16 +1,30 @@
 import * as path from "path";
 import * as fs from "fs";
 
-module.exports = function (hookArgs, $platformsData, $testExecutionService) {
-	const bundle = hookArgs && hookArgs.appFilesUpdaterOptions && hookArgs.appFilesUpdaterOptions.bundle;
-	if($testExecutionService && $testExecutionService.platform && !bundle) {
-		let platformData = $platformsData.getPlatformData($testExecutionService.platform),
-			projectFilesPath = path.join(platformData.appDestinationDirectoryPath, "app"),
-			packageJsonPath = path.join(projectFilesPath, 'package.json'),
-			packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString());
+function isCLIVersionLowerThan6($injector) {
+    try {
+        const $staticConfig = $injector.resolve('$staticConfig');
+        const version = $staticConfig && $staticConfig.version;
+        const majorVersion = (version || '').split('.')[0];
+        return !majorVersion || +majorVersion < 6;
+    } catch (err) {
+        return false;
+    }
+}
 
-		// When test command is used in ns-cli, we should change the entry point of the application
-		packageJson.main = "./tns_modules/nativescript-unit-test-runner/app.js";
-		fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+module.exports = function (hookArgs, $injector, $testExecutionService) {
+	if (isCLIVersionLowerThan6($injector)) {
+		const bundle = hookArgs && hookArgs.appFilesUpdaterOptions && hookArgs.appFilesUpdaterOptions.bundle;
+		if($testExecutionService && $testExecutionService.platform && !bundle) {
+			const $platformsData = $injector.resolve("platformsData");
+			let platformData = $platformsData.getPlatformData($testExecutionService.platform),
+				projectFilesPath = path.join(platformData.appDestinationDirectoryPath, "app"),
+				packageJsonPath = path.join(projectFilesPath, 'package.json'),
+				packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString());
+
+			// When test command is used in ns-cli, we should change the entry point of the application
+			packageJson.main = "./tns_modules/nativescript-unit-test-runner/app.js";
+			fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+		}
 	}
 }


### PR DESCRIPTION
In NativeScript CLI 6.0.0 release the bundle workflow will be the only one available. We need to execute `after-prepare` hook only when `--bundle` option is not provided e.g CLI's version is lower than 6.0.0

Current behavior: `tns test` command shows a warning `after-prepare will NOT be executed because it has invalid arguments - $platformsData.`
New behavior: `tns test` command works without showing any warning.