### PR TITLE
fix: fix legacy workflow with CLI < 5.4.2 and next version of  `nativescript-unit-test-runner`

### DIFF
--- a/lib/after-prepare.ts
+++ b/lib/after-prepare.ts
@@ -23,7 +23,7 @@ module.exports = function (hookArgs, $injector, $testExecutionService) {
 				packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString());
 
 			// When test command is used in ns-cli, we should change the entry point of the application
-			packageJson.main = "./tns_modules/nativescript-unit-test-runner/app.js";
+			packageJson.main = "./tns_modules/nativescript-unit-test-runner/app/app.js";
 			fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
 		}
 	}


### PR DESCRIPTION
As app's files are already moved to app folder, we need to change the entry point of the application when legacy workflow is used.