### PR TITLE
feat: add unitTesting gradle variable

### DIFF
--- a/lib/before-build-task-args.ts
+++ b/lib/before-build-task-args.ts
@@ -1,0 +1,8 @@
+
+module.exports = function (hookArgs, $options) {
+    if(!hookArgs || !hookArgs.args) {
+        return;
+    }
+    const unitTesting = $options && $options.env && $options.env.unitTesting || false;
+    hookArgs.args.push(`-PunitTesting=${!!unitTesting}`);
+};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
         "type": "before-liveSync",
         "script": "lib/before-liveSync.js",
         "inject": true
+      },
+      {
+        "type": "before-build-task-args",
+        "script": "lib/before-build-task-args.js",
+        "inject": true
       }
     ]
   },


### PR DESCRIPTION
this adds the `unitTesting` gradle variable at build time.

Users can then do:

```
// app.gradle
android {
  defaultConfig {
    manifestPlaceholders = [isUnitTesting:"${unitTesting}"]
  }
}

// AndroidManifest.xml
	<application
                ....
		android:usesCleartextTraffic="${isUnitTesting}"
        >
```

More advanced users that are using things like `android:networkSecurityConfig="@xml/network_security_config"` can do:

```
def securityConfig = "@xml/network_security_config";
if(unitTesting.toBoolean()) { // toBoolean() is important!
  securityConfig = "@xml/my_insecure_security_config";
}
// app.gradle
android {
  defaultConfig {
    manifestPlaceholders = [securityConfig :"${securityConfig}"]
  }
}

// AndroidManifest.xml
	<application
                ....
		android:networkSecurityConfig="${securityConfig}"
        >
```