### PR TITLE
fix: ensure compatibility running test-loader last

### DIFF
--- a/nativescript.webpack.js
+++ b/nativescript.webpack.js
@@ -62,6 +62,7 @@ function setupKarmaBuild(config, env, webpack) {
 
   config.module
     .rule('unit-test')
+    .enforce('post')
     .include.add(webpack.Utils.platform.getEntryDirPath()).end()
     .test(/\.(ts|js)/)
     .use('unit-test-loader')


### PR DESCRIPTION
This fixes an issue where unit-test-loader is ignored in angular 12