### PR TITLE
fix: replace all separators with /

### DIFF
--- a/loaders/unit-test-loader.js
+++ b/loaders/unit-test-loader.js
@@ -11,7 +11,7 @@ module.exports = function unitTestLoader(source, map) {
   const opts = this.getOptions();
   const testPathRelativeToAppPath = relative(opts.appPath, this.resourcePath);
   const ext = extname(testPathRelativeToAppPath);
-  const loadPath = testPathRelativeToAppPath.replace(ext, "").replace(sep, '/'); // use forward slash always
+  const loadPath = testPathRelativeToAppPath.replace(ext, "").split(sep).join('/'); // use forward slash always
 
   if (loadPath) {
     const platformExt = loadPath.split('.').slice(-1)[0];


### PR DESCRIPTION
fixes issues where on windows it would resolve to:

`test/a\b` instead of `test/a/b`