### PR TITLE
feat: allow Vitest sessions on tvOS

### DIFF
--- a/src/node/options.spec.ts
+++ b/src/node/options.spec.ts
@@ -165,3 +165,14 @@ describe('resolveNativeScriptPluginOptions', () => {
     );
   });
 });
+
+
+describe('tvOS', () => {
+  it('accepts CLI casing and launches the tvOS platform without adb', () => {
+    const options = resolveNativeScriptPluginOptions({ platform: 'tvOS', device: 'apple-tv' });
+    expect(options.platform).toBe('tvos');
+    expect(options.launchCommand.args).toContain('tvos');
+    expect(options.launchCommand.args).toContain('apple-tv');
+    expect(options.adbReverse).toBe(false);
+  });
+});

--- a/src/node/options.ts
+++ b/src/node/options.ts
@@ -10,7 +10,7 @@ import { resolveNativeScriptWorkerCount } from '../threading.js';
 
 export { DEFAULT_NATIVE_SCRIPT_VITEST_PORT } from '../protocol.js';
 
-export type NativeScriptPlatform = 'android' | 'ios' | 'visionos';
+export type NativeScriptPlatform = 'android' | 'ios' | 'visionos' | 'tvos';
 
 /**
  * Canonical platform ids plus the loose spellings that reach the plugin via
@@ -22,6 +22,7 @@ const NATIVE_SCRIPT_PLATFORMS: readonly NativeScriptPlatform[] = [
   'android',
   'ios',
   'visionos',
+  'tvos',
 ];
 
 const NATIVE_SCRIPT_PLATFORM_ALIASES: Record<string, NativeScriptPlatform> = {


### PR DESCRIPTION
Accept tvOS as an Apple platform in the Vitest runner options and launch-command normalization.

## Validation

All 71 host tests passed. The final source-built tvOS simulator app runs five native integration tests through ns test tvos. The fixture injects a Foundation WebSocket transport because the default @valor/nativescript-websockets binary lacks a tvOS slice; an unchanged ns test init scaffold is not claimed to work.

## Reproduce

[Revision-pinned reviewer setup](https://github.com/LorenzGit/ios/blob/5ba786daf42bbadf2c0cb8f9f856df698babd11c/tools/tvos-review/README.md) builds the companion stack in an isolated workspace. It includes commands, requirements, dependency pins and physical-device limitations. No binary artifacts or private development paths are committed.

This PR contains one commit, `a2934e4cfff0d32d099ee82870e430ecd5cc1b4e`, changing 2 files against `45472523e988c9d40ae8df2a70dfde0f1c89bf7a`. Its exported patch reproduces the committed tree from a fresh base index.

The source-built runtime was validated in the prepared runtime checkout; companion clones, native helpers, Canvas and clean npm installation were validated in a separate workspace on the same Mac. A second machine and one uninterrupted cold `all` run have not been tested.
